### PR TITLE
fix: stabilize jump buffering

### DIFF
--- a/main.js
+++ b/main.js
@@ -162,7 +162,11 @@
         return;
       }
       const k = KeyMapDown[e.code]; if (!k) return;
-      if (k === 'overlay') toggleOverlay(); else Keys[k] = true;
+      if (k === 'overlay') toggleOverlay();
+      else {
+        Keys[k] = true;
+        if (k === 'jump') state.jumpBufferedAt = performance.now();
+      }
     });
 
     window.addEventListener('keyup', e => {
@@ -482,7 +486,6 @@
         if (state.vx < target) state.vx = Math.min(target, state.vx + a * dt);
         else if (state.vx > target) state.vx = Math.max(target, state.vx - a * dt);
 
-        if (Keys.jump) state.jumpBufferedAt = now;
         const canCoyote = (now - state.lastGrounded) <= stats.coyoteTime * 1000;
         const buffered = (now - state.jumpBufferedAt) <= stats.inputBuffer * 1000;
         if (buffered && (state.onGround || canCoyote)) {


### PR DESCRIPTION
## Summary
- handle jump buffering on key press to avoid unintended re-triggering
- keep coyote time and input buffer logic clean

## Testing
- `node --check main.js`


------
https://chatgpt.com/codex/tasks/task_e_68c696bdc228832f8b79f0156f755b0e