### PR TITLE
feat: enemy foundations

### DIFF
--- a/index.html
+++ b/index.html
@@ -55,7 +55,7 @@ html, body { height:100%; margin:0; background:#000; }
 
     <!-- Debug overlay & key hint -->
     <div id="overlay"></div>
-    <div class="badge">Move: A/D or ←/→ • Jump: Space • Roll: L • Parry: Shift • Light: J • Heavy: K • Flask: F • Overlay: F9</div>
+    <div class="badge">Move: A/D or ←/→ • Jump: Space • Roll: L • Parry: Shift • Light: J • Heavy: K • Flask: F • Overlay: F9 • Enemy Debug: F10</div>
 
     <script src="main.js"></script>
   </body>


### PR DESCRIPTION
## Summary
- add F10 enemy debug toggle showing state labels and bounds
- spawn prototype Wolf and Bat enemies with simple patrol/chase logic
- integrate enemy updates into overlay and main loop
- stop Wolf jittering on top of the player so it no longer sticks when it reaches the hero

## Testing
- `node --check main.js`


------
https://chatgpt.com/codex/tasks/task_e_68c6992607f8832fb838a11b08ab1a7d