### PR TITLE
Add WebAudio initialization and debug toggles

### DIFF
--- a/data/entities.schema.json
+++ b/data/entities.schema.json
@@ -1,0 +1,18 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Entity",
+  "type": "object",
+  "properties": {
+    "id": { "type": "string" },
+    "type": { "type": "string" },
+    "position": {
+      "type": "object",
+      "properties": {
+        "x": { "type": "number" },
+        "y": { "type": "number" }
+      },
+      "required": ["x", "y"]
+    }
+  },
+  "required": ["id", "type"]
+}

--- a/data/hitboxes.schema.json
+++ b/data/hitboxes.schema.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Hitbox",
+  "type": "object",
+  "properties": {
+    "shape": { "type": "string", "enum": ["rect", "circle"] },
+    "offset": {
+      "type": "object",
+      "properties": {
+        "x": { "type": "number" },
+        "y": { "type": "number" }
+      },
+      "required": ["x", "y"]
+    },
+    "size": {
+      "type": "object",
+      "properties": {
+        "width": { "type": "number" },
+        "height": { "type": "number" },
+        "radius": { "type": "number" }
+      }
+    }
+  },
+  "required": ["shape"]
+}

--- a/data/rooms.schema.json
+++ b/data/rooms.schema.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Room",
+  "type": "object",
+  "properties": {
+    "id": { "type": "string" },
+    "name": { "type": "string" },
+    "size": {
+      "type": "object",
+      "properties": {
+        "width": { "type": "number" },
+        "height": { "type": "number" }
+      },
+      "required": ["width", "height"]
+    },
+    "entities": {
+      "type": "array",
+      "items": { "$ref": "entities.schema.json" }
+    }
+  },
+  "required": ["id", "size"]
+}


### PR DESCRIPTION
## Summary
- init AudioContext after Babylon engine setup
- add slow-mo and collider mesh toggles with overlay indicators
- scaffold JSON schemas for entities, rooms, and hitboxes

## Testing
- `node --check main.js && echo 'syntax ok'`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c6ece3771c832f9253a17a329ff408