### PR TITLE
Add climbing animations and revert campfire shrine

### DIFF
--- a/main.js
+++ b/main.js
@@ -77,6 +77,8 @@
     const engine = new BABYLON.Engine(canvas, true, { preserveDrawingBuffer: true, stencil: true });
     const scene = new BABYLON.Scene(engine);
     scene.clearColor = new BABYLON.Color4(0, 0, 0, 1);
+    const glow = new BABYLON.GlowLayer('glow', scene);
+    glow.intensity = 0.6;
 
     // ---- WebAudio ----
     const audioCtx = new (window.AudioContext || window.webkitAudioContext)();
@@ -125,6 +127,9 @@
     // World objects
     const ladders = [];
     const shrines = [];
+    const campfireMeta = { url: 'assets/sprites/Campfire/CampFire.png', frames: 5, fps: 8 };
+    let campfireMgr = null;
+    let campfireSizeUnits = 1;
     const respawnKey = 'eotr_respawn';
     let respawn = JSON.parse(localStorage.getItem(respawnKey) || 'null');
     if (respawn) {
@@ -141,12 +146,48 @@
       ladders.push({ x, y0, y1, width, mesh });
       return ladders[ladders.length - 1];
     }
-    function spawnShrine(x, y) {
+    async function spawnShrine(x, y) {
       const mesh = BABYLON.MeshBuilder.CreateCylinder('shrine', { height: 1.5, diameter: 0.5 }, scene);
       mesh.position.set(x, y + 0.75, 0);
-      const mat = new BABYLON.StandardMaterial('shrineMat', scene);
-      mat.emissiveColor = new BABYLON.Color3(0.7, 0.7, 1.0);
-      mesh.material = mat;
+      mesh.isVisible = false;
+
+      if (!campfireMgr) {
+        const { ok, w: sheetW, h: sheetH } = await loadImage(campfireMeta.url);
+        if (ok) {
+          const frameW = Math.floor(sheetW / campfireMeta.frames);
+          const frameH = sheetH;
+          campfireSizeUnits = frameH / PPU;
+          campfireMgr = new BABYLON.SpriteManager('campfireMgr', campfireMeta.url, 1, { width: frameW, height: frameH }, scene);
+          campfireMgr.texture.updateSamplingMode(BABYLON.Texture.NEAREST_SAMPLINGMODE);
+          campfireMgr.texture.wrapU = BABYLON.Texture.CLAMP_ADDRESSMODE;
+          campfireMgr.texture.wrapV = BABYLON.Texture.CLAMP_ADDRESSMODE;
+        }
+      }
+      if (campfireMgr) {
+        const sp = new BABYLON.Sprite('campfire', campfireMgr);
+        const fireScale = 0.6;
+        sp.size = campfireSizeUnits * fireScale;
+        sp.position = new BABYLON.Vector3(x, y + sp.size * 0.5, 0);
+        sp.playAnimation(0, campfireMeta.frames - 1, true, 1000 / (campfireMeta.fps || 8));
+        sp.useAlphaForGlow = true;
+        sp.color = new BABYLON.Color4(1, 1, 1, 1);
+
+        const baseY = sp.position.y - sp.size * 0.5;
+        const radii = [sp.size * 0.4, sp.size * 0.8, sp.size * 1.2];
+        const alphas = [0.1, 0.05, 0.02];
+        radii.forEach((r, i) => {
+          const light = BABYLON.MeshBuilder.CreateDisc(`campLight${i}`, { radius: r, tessellation: 24 }, scene);
+          light.billboardMode = BABYLON.Mesh.BILLBOARDMODE_ALL;
+          light.position.set(sp.position.x, baseY, sp.position.z + i * 0.001);
+          const lmat = new BABYLON.StandardMaterial(`campLightMat${i}`, scene);
+          lmat.diffuseColor = new BABYLON.Color3(0, 0, 0);
+          lmat.specularColor = new BABYLON.Color3(0, 0, 0);
+          lmat.emissiveColor = new BABYLON.Color3(0.8, 0.4, 0.05);
+          lmat.alpha = alphas[i];
+          light.material = lmat;
+        });
+      }
+
       shrines.push({ x, y, mesh });
       return shrines[shrines.length - 1];
     }
@@ -284,6 +325,8 @@
       // Air & heavy
       jump:   { url: 'assets/sprites/player/Jump.png',   frames: 3,  fps: 16, loop: true },
       fall:   { url: 'assets/sprites/player/Fall.png',   frames: 3,  fps: 16, loop: true },
+      climbUp:   { url: 'assets/sprites/player/LadderUp.png',   frames: 7, fps: 12, loop: true },
+      climbDown: { url: 'assets/sprites/player/LadderDown.png', frames: 7, fps: 12, loop: true },
       heavy:  { url: 'assets/sprites/player/Heavy.png',  frames: 6,  fps: 12, loop: false },
 
       // Hurt + Death
@@ -381,6 +424,10 @@
       const walkMgr = await createManagerAuto('walk');   if (walkMgr.ok)  playerSprite.mgr.walk  = walkMgr.mgr;
       const runMgr  = await createManagerAuto('run');    if (runMgr.ok)   playerSprite.mgr.run   = runMgr.mgr;
       const rollMgr = await createManagerAuto('roll');   if (rollMgr.ok)  playerSprite.mgr.roll  = rollMgr.mgr;
+
+      // Ladder climb
+      const cu = await createManagerAuto('climbUp');   if (cu.ok) playerSprite.mgr.climbUp = cu.mgr;
+      const cd = await createManagerAuto('climbDown'); if (cd.ok) playerSprite.mgr.climbDown = cd.mgr;
 
       // Light combo
       const l1 = await createManagerAuto('light1'); if (l1.ok) playerSprite.mgr.light1 = l1.mgr;
@@ -885,6 +932,10 @@
 
         if (state.blocking) {
           targetAnim = 'block'; // override while holding block
+        } else if (state.climbing) {
+          if (state.vy > 0.15) targetAnim = 'climbUp';
+          else if (state.vy < -0.15) targetAnim = 'climbDown';
+          else targetAnim = 'climbUp';
         } else if (!state.onGround) {
           if (state.vy > 0.15) targetAnim = 'jump';
           else if (state.vy < -0.15) targetAnim = 'fall';


### PR DESCRIPTION
## Summary
- Enable glow layer and campfire sprite with concentric light discs
- Anchor glow discs at the base of the campfire so light spreads from the fire
- Introduce climb-up and climb-down animations for ladder traversal

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open '/workspace/echoes-ruin/package.json')*

------
https://chatgpt.com/codex/tasks/task_e_68c71adfa2e0832f8798417b0c9ca82e