### PR TITLE
Prevent landing animation flash during rapid jumps

### DIFF
--- a/main.js
+++ b/main.js
@@ -9,6 +9,7 @@
   const ORTHO_VIEW_HEIGHT = 12;         // vertical world units in view
   const PARRY_WINDOW_MS = 120;          // parry window + parry anim duration
   const HOLD_THRESHOLD_MS = 180;        // how long E must be held to count as Block (not Parry)
+  const LANDING_MIN_GROUNDED_MS = 1;    // delay landing anim until on-ground persisted into next frame
 
   // Ensure CSS (fallback if external fails)
   (function ensureCss() {
@@ -294,7 +295,10 @@
       blocking: false,
       parryOpen: false,
       parryUntil: 0,
-      climbing: false
+      climbing: false,
+      landing: false,
+      landingStartAt: 0,
+      landingUntil: 0
     };
 
     // === HUD refs ===
@@ -325,6 +329,7 @@
       // Air & heavy
       jump:   { url: 'assets/sprites/player/Jump.png',   frames: 3,  fps: 16, loop: true },
       fall:   { url: 'assets/sprites/player/Fall.png',   frames: 3,  fps: 16, loop: true },
+      landing: { url: 'assets/sprites/player/Landing.png', frames: 5,  fps: 20, loop: false },
       climbUp:   { url: 'assets/sprites/player/LadderUp.png',   frames: 7, fps: 12, loop: true },
       climbDown: { url: 'assets/sprites/player/LadderDown.png', frames: 7, fps: 12, loop: true },
       heavy:  { url: 'assets/sprites/player/Heavy.png',  frames: 6,  fps: 12, loop: false },
@@ -435,8 +440,9 @@
       const l3 = await createManagerAuto('light3'); if (l3.ok) playerSprite.mgr.light3 = l3.mgr;
 
       // Air & heavy
-      const j  = await createManagerAuto('jump');  if (j.ok)  playerSprite.mgr.jump  = j.mgr;
-      const f  = await createManagerAuto('fall');  if (f.ok)  playerSprite.mgr.fall  = f.mgr;
+      const j  = await createManagerAuto('jump');    if (j.ok)  playerSprite.mgr.jump    = j.mgr;
+      const f  = await createManagerAuto('fall');    if (f.ok)  playerSprite.mgr.fall    = f.mgr;
+      const la = await createManagerAuto('landing'); if (la.ok) playerSprite.mgr.landing = la.mgr;
       const hv = await createManagerAuto('heavy'); if (hv.ok) playerSprite.mgr.heavy = hv.mgr;
 
       // Hurt + Death
@@ -905,12 +911,16 @@
       }
 
       // Physics (drive placeholder)
+      const wasOnGround = state.onGround;
+      let vyBefore = state.vy;
       if (!state.dead) {
         if (state.climbing) {
+          vyBefore = state.vy;
           placeholder.position.x += state.vx * dt;
           placeholder.position.y += state.vy * dt;
         } else {
           state.vy += stats.gravity * dt;
+          vyBefore = state.vy;
           placeholder.position.x += state.vx * dt;
           placeholder.position.y += state.vy * dt;
         }
@@ -918,13 +928,30 @@
 
       // Ground clamp (feet at y=0 => center at feetCenterY)
       const groundCenter = feetCenterY();
+      let justLanded = false;
       if (placeholder.position.y <= groundCenter) {
         placeholder.position.y = groundCenter;
         if (!state.onGround) state.lastGrounded = now;
         state.onGround = true;
         if (state.vy < 0) state.vy = 0;
+        justLanded = !wasOnGround;
       } else {
         state.onGround = false;
+      }
+
+      if (justLanded) {
+        const landingMeta = SHEETS.landing;
+        const falling = vyBefore < -0.2;
+        const jumpBuffered = state.jumpBufferedAt &&
+          (now - state.jumpBufferedAt) <= stats.inputBuffer * 1000;
+        const canTriggerLanding = falling && landingMeta && playerSprite.mgr.landing && playerSprite.sprite &&
+          !state.rolling && (!state.acting || state.flasking) && !state.blocking && !state.dead && !jumpBuffered;
+        if (canTriggerLanding) {
+          const dur = (landingMeta.frames / landingMeta.fps) * 1000;
+          state.landing = true;
+          state.landingStartAt = now + LANDING_MIN_GROUNDED_MS;
+          state.landingUntil = state.landingStartAt + dur;
+        }
       }
 
       // Drive sprite from placeholder
@@ -942,11 +969,25 @@
       shadow.scaling.z = playerSprite.sizeUnits * 0.35 * shrink;
 
       // Animation state machine (skip while rolling/dead/other actions)
+      let landingActive = false;
+      if (state.landing) {
+        const eligibleNow = state.onGround && !state.blocking && now < state.landingUntil;
+        if (!eligibleNow) {
+          state.landing = false;
+          state.landingStartAt = 0;
+          state.landingUntil = 0;
+        } else if (now >= state.landingStartAt) {
+          landingActive = true;
+        }
+      }
+
       const allowStateMachine = !state.rolling && (!state.acting || state.flasking) && !state.dead && playerSprite.sprite;
       if (allowStateMachine) {
         let targetAnim = 'idle';
 
-        if (state.blocking) {
+        if (landingActive) {
+          targetAnim = 'landing';
+        } else if (state.blocking) {
           targetAnim = 'block'; // override while holding block
         } else if (state.climbing) {
           if (state.vy > 0.15) targetAnim = 'climbUp';
@@ -960,7 +1001,10 @@
           targetAnim = moving ? (Keys.runHold ? 'run' : 'walk') : 'idle';
         }
 
-        if (playerSprite.state !== targetAnim) setAnim(targetAnim, true);
+        if (playerSprite.state !== targetAnim) {
+          const loopOverride = (targetAnim === 'landing') ? false : true;
+          setAnim(targetAnim, loopOverride);
+        }
       }
 
       // Camera follow (x only)


### PR DESCRIPTION
## Summary
- add a minimal grounded delay constant and state timing to gate the landing animation
- queue the landing clip to start only after the hero has remained grounded past the delay
- cancel pending landings if the hero leaves the ground early so rapid jump spamming no longer flashes the landing frame

## Testing
- node --check main.js

------
https://chatgpt.com/codex/tasks/task_e_68c8e82711ec832f926a0c848ff747c9