### PR TITLE
Replace kneel flask sequence with centered flash overlay

### DIFF
--- a/main.js
+++ b/main.js
@@ -295,6 +295,9 @@
       rolling: false, rollT: 0, iFramed: false,
       acting: false, facing: 1, dead: false,
       flasking: false,
+      flaskStart: 0,
+      flaskEndAt: 0,
+      flaskHealApplied: false,
 
       // New
       blocking: false,
@@ -326,6 +329,8 @@
       walk:   { url: 'assets/sprites/player/Walk.png',   frames: 8,  fps: 12, loop: true },
       run:    { url: 'assets/sprites/player/Run.png',    frames: 8,  fps: 14, loop: true },
       roll:   { url: 'assets/sprites/player/Roll.png',   frames: 5,  fps: 18, loop: true },
+      kneelDown: { url: 'assets/sprites/player/KneelDown.png', frames: 5, fps: 12, loop: false },
+      kneelUp:   { url: 'assets/sprites/player/KneelUp.png',   frames: 5, fps: 12, loop: false },
 
       // Light combo
       light1: { url: 'assets/sprites/player/Light1.png', frames: 4,  fps: 16, loop: false, cancelFrac: 0.6, next: 'light2' },
@@ -351,6 +356,7 @@
 
     const playerSprite = {
       mgr: {},
+      sizeByAnim: {},
       sprite: null,
       state: 'idle',
       sizeUnits: 2,
@@ -358,6 +364,19 @@
       animStarted: 0,
       animDurationMs: 0,
       loop: true
+    };
+
+    const HEAL_FX_META = { url: 'assets/sprites/Heal/heal.png', frames: 6, fps: 6.6667 };
+    const healFx = { mgr: null, sprite: null, sizeUnits: 0, animStart: 0, animDuration: 0, frameH: 0 };
+    const healFlash = {
+      mesh: null,
+      mat: null,
+      active: false,
+      start: 0,
+      end: 0,
+      maxAlpha: 0.45,
+      fadeIn: 150,
+      fadeOut: 220
     };
 
     // Attack/Action timing
@@ -377,7 +396,8 @@
       const frameH = Math.floor(sheetH / rows);
 
       // Height in world units from pixel height
-      playerSprite.sizeUnits = frameH / PPU;
+      const sizeUnits = frameH / PPU;
+      playerSprite.sizeByAnim[metaKey] = sizeUnits;
 
       // Baseline auto-detect (idle only)
       if (computeBaseline) {
@@ -391,7 +411,7 @@
       mgr.texture.wrapU = BABYLON.Texture.CLAMP_ADDRESSMODE; // avoid UV wrapping on odd sheets
       mgr.texture.wrapV = BABYLON.Texture.CLAMP_ADDRESSMODE;
 
-      console.log(`[Sprite] ${metaKey}: sheet ${sheetW}x${sheetH}, frames=${meta.frames}, cell ${frameW}x${frameH}, sizeUnits=${playerSprite.sizeUnits.toFixed(2)}`);
+      console.log(`[Sprite] ${metaKey}: sheet ${sheetW}x${sheetH}, frames=${meta.frames}, cell ${frameW}x${frameH}, sizeUnits=${sizeUnits.toFixed(2)}`);
       return { ok: true, mgr, frameW, frameH };
     }
 
@@ -409,7 +429,8 @@
       old.dispose();
 
       const sp = new BABYLON.Sprite('playerSprite', mgr);
-      sp.size = playerSprite.sizeUnits;
+      const sizeUnits = playerSprite.sizeByAnim[name] ?? playerSprite.sizeUnits;
+      sp.size = sizeUnits;
       sp.position = new BABYLON.Vector3(pos.x, pos.y, 0);
       sp.invertU = facingLeft;
       const loop = (typeof loopOverride === 'boolean') ? loopOverride : !!meta.loop;
@@ -420,9 +441,129 @@
 
       playerSprite.sprite = sp;
       playerSprite.state = name;
+      playerSprite.sizeUnits = sizeUnits;
       playerSprite.loop = loop;
       playerSprite.animStarted = performance.now();
       playerSprite.animDurationMs = (meta.frames / meta.fps) * 1000;
+    }
+
+    async function initHealFx() {
+      const { ok, w: sheetW, h: sheetH } = await loadImage(HEAL_FX_META.url);
+      if (!ok) { console.warn('Heal FX sheet missing; skipping.'); return; }
+      const frameW = Math.floor(sheetW / HEAL_FX_META.frames);
+      const frameH = sheetH;
+      healFx.sizeUnits = frameH / PPU;
+      healFx.frameH = frameH;
+      healFx.animDuration = (HEAL_FX_META.frames / HEAL_FX_META.fps) * 1000;
+      const mgr = new BABYLON.SpriteManager('fx_heal', HEAL_FX_META.url, 1,
+        { width: frameW, height: frameH }, scene);
+      mgr.texture.updateSamplingMode(BABYLON.Texture.NEAREST_SAMPLINGMODE);
+      mgr.texture.wrapU = BABYLON.Texture.CLAMP_ADDRESSMODE;
+      mgr.texture.wrapV = BABYLON.Texture.CLAMP_ADDRESSMODE;
+      healFx.mgr = mgr;
+    }
+
+    function playHealFx() {
+      if (!healFx.mgr) return;
+      if (healFx.sprite) { healFx.sprite.dispose(); healFx.sprite = null; }
+      const sp = new BABYLON.Sprite('fx_heal_active', healFx.mgr);
+      sp.size = healFx.sizeUnits;
+      sp.position = new BABYLON.Vector3(placeholder.position.x, placeholder.position.y, 0);
+      sp.playAnimation(0, HEAL_FX_META.frames - 1, false, 1000 / HEAL_FX_META.fps);
+      healFx.sprite = sp;
+      healFx.animStart = performance.now();
+    }
+
+    function stopHealFx() {
+      if (healFx.sprite) {
+        healFx.sprite.dispose();
+        healFx.sprite = null;
+      }
+      healFx.animStart = 0;
+    }
+
+    function initHealFlash() {
+      const mesh = BABYLON.MeshBuilder.CreatePlane('healFlashPlane', { width: 1, height: 1 }, scene);
+      mesh.billboardMode = BABYLON.Mesh.BILLBOARDMODE_ALL;
+      mesh.isPickable = false;
+      mesh.position.z = -0.01;
+      mesh.renderingGroupId = 1;
+      mesh.setEnabled(false);
+      const mat = new BABYLON.StandardMaterial('healFlashMat', scene);
+      mat.emissiveColor = new BABYLON.Color3(1, 1, 1);
+      mat.disableLighting = true;
+      mat.alpha = 0;
+      mat.backFaceCulling = false;
+      mat.disableDepthWrite = true;
+      mat.alphaMode = BABYLON.Engine.ALPHA_ADD;
+      mesh.material = mat;
+      healFlash.mesh = mesh;
+      healFlash.mat = mat;
+    }
+
+    function playHealFlash() {
+      if (!healFlash.mesh) return;
+      const now = performance.now();
+      healFlash.active = true;
+      healFlash.start = now;
+      healFlash.end = now + stats.flaskSip * 1000;
+      healFlash.mat.alpha = 0;
+      healFlash.mesh.setEnabled(true);
+    }
+
+    function stopHealFlash() {
+      if (!healFlash.mesh) return;
+      healFlash.active = false;
+      healFlash.mesh.setEnabled(false);
+      if (healFlash.mat) healFlash.mat.alpha = 0;
+      healFlash.start = 0;
+      healFlash.end = 0;
+    }
+
+    function updateHealFlash(now) {
+      if (!healFlash.mesh) return;
+      if (!healFlash.mat) return;
+      healFlash.mesh.position.x = placeholder.position.x;
+      healFlash.mesh.position.y = placeholder.position.y;
+      const size = playerSprite.sizeUnits || 1.8;
+      healFlash.mesh.scaling.x = size * 0.55;
+      healFlash.mesh.scaling.y = size * 1.05;
+      if (!healFlash.active) return;
+      if (now >= healFlash.end) {
+        stopHealFlash();
+        return;
+      }
+      const total = healFlash.end - healFlash.start;
+      if (total <= 0) {
+        stopHealFlash();
+        return;
+      }
+      const t = now - healFlash.start;
+      const fadeIn = healFlash.fadeIn;
+      const fadeOut = healFlash.fadeOut;
+      let alpha = healFlash.maxAlpha;
+      if (t < fadeIn) {
+        alpha = healFlash.maxAlpha * (t / fadeIn);
+      } else if (t > total - fadeOut) {
+        const remain = Math.max(0, total - t);
+        alpha = healFlash.maxAlpha * (remain / fadeOut);
+      }
+      healFlash.mat.alpha = Math.max(0, Math.min(healFlash.maxAlpha, alpha));
+    }
+
+    function cleanupFlaskState({ keepActing = false, stopFx = true } = {}) {
+      if (state.flasking) {
+        state.flasking = false;
+        state.flaskStart = 0;
+        state.flaskEndAt = 0;
+        state.flaskHealApplied = false;
+      }
+      stats.flaskLock = 0;
+      if (stopFx) {
+        stopHealFx();
+        stopHealFlash();
+      }
+      if (!keepActing) state.acting = false;
     }
 
     async function initPlayerSprite() {
@@ -430,11 +571,14 @@
       const idleMgr = await createManagerAuto('idle', true);
       if (!idleMgr.ok) { console.warn('Idle sheet missing; keeping placeholder.'); return; }
       playerSprite.mgr.idle = idleMgr.mgr;
+      playerSprite.sizeUnits = playerSprite.sizeByAnim.idle ?? playerSprite.sizeUnits;
 
       // Movement
       const walkMgr = await createManagerAuto('walk');   if (walkMgr.ok)  playerSprite.mgr.walk  = walkMgr.mgr;
       const runMgr  = await createManagerAuto('run');    if (runMgr.ok)   playerSprite.mgr.run   = runMgr.mgr;
       const rollMgr = await createManagerAuto('roll');   if (rollMgr.ok)  playerSprite.mgr.roll  = rollMgr.mgr;
+      const kneelDMgr = await createManagerAuto('kneelDown'); if (kneelDMgr.ok) playerSprite.mgr.kneelDown = kneelDMgr.mgr;
+      const kneelUMgr = await createManagerAuto('kneelUp');   if (kneelUMgr.ok) playerSprite.mgr.kneelUp = kneelUMgr.mgr;
 
       // Ladder climb
       const cu = await createManagerAuto('climbUp');   if (cu.ok) playerSprite.mgr.climbUp = cu.mgr;
@@ -473,6 +617,8 @@
       placeholder.setEnabled(false);
     }
       initPlayerSprite();
+      initHealFx();
+      initHealFlash();
       createLadder(2, 0, 4);
       spawnShrine(-2, 0);
 
@@ -672,6 +818,7 @@
       // === Actions ===
     function triggerParry() {
       if (state.dead || state.blocking) return;
+      if (state.flasking) cleanupFlaskState({ keepActing: true });
       state.parryOpen = true;
       state.parryUntil = performance.now() + PARRY_WINDOW_MS;
 
@@ -693,31 +840,31 @@
     }
 
     function tryFlask() {
-      if (state.dead || stats.flaskCount <= 0 || state.acting) return;
+      if (state.dead || stats.flaskCount <= 0 || state.rolling || state.blocking) return;
+      if (state.acting && !state.flasking) return;
+      if (state.flasking) return;
       setFlasks(stats.flaskCount - 1);
+      const now = performance.now();
       state.acting = true;
       state.flasking = true;
-      const start = performance.now();
-      stats.flaskLock = start + stats.flaskRollCancel * 1000;
-      const sip = setInterval(() => {
-        const t = performance.now() - start;
-        if (state.rolling && performance.now() > stats.flaskLock) {
-          clearInterval(sip);
-          state.flasking = false;
-          state.acting = false;
-          return;
-        }
-        if (t >= stats.flaskSip * 1000) {
-          clearInterval(sip);
-          setHP(stats.hp + stats.hpMax * stats.flaskHealPct);
-          state.flasking = false;
-          state.acting = false;
-        }
-      }, 10);
+      state.flaskStart = now;
+      state.flaskEndAt = now + stats.flaskSip * 1000;
+      state.flaskHealApplied = false;
+      stats.flaskLock = now + stats.flaskRollCancel * 1000;
+      if (playerSprite.mgr.idle) setAnim('idle', true);
+      playHealFx();
+      playHealFlash();
     }
 
     function startRoll() {
-      if (state.dead || state.rolling || state.acting || stats.stam < stats.rollCost) return;
+      if (state.dead || state.rolling) return;
+      const flasking = state.flasking;
+      if (state.acting && !flasking) return;
+      if (stats.stam < stats.rollCost) return;
+      if (flasking) {
+        if (!state.flaskHealApplied) return;
+        cleanupFlaskState();
+      }
       setST(stats.stam - stats.rollCost);
       state.rolling = true; state.rollT = 0; state.iFramed = false;
       setAnim('roll', true);
@@ -729,6 +876,7 @@
       const name = stage === 1 ? 'light1' : stage === 2 ? 'light2' : 'light3';
       const meta = SHEETS[name]; if (!meta || !playerSprite.mgr[name]) return false;
       if (stats.stam < stats.lightCost) return false;
+      if (state.flasking) cleanupFlaskState({ keepActing: true });
       setST(stats.stam - stats.lightCost);
       state.flasking = false;
       state.acting = true; combo.stage = stage; combo.queued = false;
@@ -760,6 +908,7 @@
     // Hurt + Death
     function triggerHurt(dmg = 15) {
       if (state.dead) return;
+      if (state.flasking) cleanupFlaskState({ keepActing: true });
       setHP(stats.hp - dmg);
       if (stats.hp <= 0) { die(); return; }
       state.flasking = false;
@@ -769,6 +918,7 @@
     }
     function die() {
       if (state.dead) return;
+      if (state.flasking) cleanupFlaskState({ keepActing: true });
       state.dead = true; state.acting = true; state.flasking = false; state.vx = 0; state.vy = 0;
       state.blocking = false; state.parryOpen = false;
       combo.stage = 0; combo.queued = false;
@@ -823,6 +973,16 @@
       const rawDt = engine.getDeltaTime() / 1000;
       const dt = rawDt * (slowMo ? 0.25 : 1);
       const now = performance.now();
+
+      if (state.flasking) {
+        if (!state.flaskHealApplied && now >= stats.flaskLock) {
+          setHP(stats.hp + stats.hpMax * stats.flaskHealPct);
+          state.flaskHealApplied = true;
+        }
+        if (now >= state.flaskEndAt) {
+          cleanupFlaskState({ stopFx: false });
+        }
+      }
 
       // Ladder detection
       const ladder = ladders.find(l =>
@@ -917,6 +1077,7 @@
       // Handle generic action end (hurt, heavy, parry, death)
       if (state.acting && actionEndAt && now >= actionEndAt) {
         if (state.dead) startRespawn();
+        else if (state.flasking) cleanupFlaskState();
         else state.acting = false;
         actionEndAt = 0;
         state.parryOpen = false; // ensure parry window is closed
@@ -981,6 +1142,14 @@
         playerSprite.sprite.position.y = placeholder.position.y;
         playerSprite.sprite.invertU = (state.facing < 0);
       }
+      if (healFx.sprite) {
+        healFx.sprite.position.x = placeholder.position.x;
+        healFx.sprite.position.y = placeholder.position.y;
+        if (!state.flasking && healFx.animStart && now >= healFx.animStart + healFx.animDuration) {
+          stopHealFx();
+        }
+      }
+      updateHealFlash(now);
 
       // Shadow follows X; tiny shrink when airborne
       shadow.position.x = placeholder.position.x;
@@ -1007,7 +1176,7 @@
         }
       }
 
-      const allowStateMachine = !state.rolling && (!state.acting || state.flasking) && !state.dead && playerSprite.sprite;
+      const allowStateMachine = !state.rolling && !state.acting && !state.dead && playerSprite.sprite;
       if (allowStateMachine) {
         let targetAnim = 'idle';
 


### PR DESCRIPTION
## Summary
- drop the kneel-up/down sequence and the heal-screen vignette from the flask action
- add a torso-following additive white flash plane and keep it fading in/out through the flask channel
- keep the heal sprite but center it on the hero while delaying roll cancels until the heal lands

## Testing
- not run (not available)

------
https://chatgpt.com/codex/tasks/task_e_68c914433cbc832fbc74eb4a3ee85868