### PR TITLE
Refine hitboxes, poise regen, and wolf AI

### DIFF
--- a/index.html
+++ b/index.html
@@ -13,6 +13,7 @@
 
   <body>
     <canvas id="game-canvas" style="width:100vw;height:100vh;display:block;"></canvas>
+    <canvas id="hitbox-debug"></canvas>
 
     <!-- HUD -->
     <div id="hud">

--- a/style.css
+++ b/style.css
@@ -1,6 +1,15 @@
 html, body { height:100%; margin:0; background:#000; }
 #game-canvas { width:100vw; height:100vh; display:block;
   image-rendering: pixelated; image-rendering: crisp-edges; }
+#hitbox-debug {
+  position: fixed;
+  left: 0;
+  top: 0;
+  width: 100vw;
+  height: 100vh;
+  pointer-events: none;
+  z-index: 600;
+}
 
 /* === HUD === */
 #hud {


### PR DESCRIPTION
## Summary
- add a hitbox debug overlay and scale-aware frame libraries for the player’s sword swings and wolf claws
- extend the combat system to resolve per-frame socketed hitboxes and smoothly interpolate poise regeneration
- refine wolf AI with pack role assignment, parabolic leap movement, and reliable run-to-attack transitions

## Testing
- node --check main.js

------
https://chatgpt.com/codex/tasks/task_e_68cd2894efc0832fa1b328e305f41b63