### PR TITLE
Implement block mitigation tuning and parry ready FX

### DIFF
--- a/main.js
+++ b/main.js
@@ -12,6 +12,7 @@
   const GUARD_BREAK_STUN_MS = 650;      // block break stun duration
   const BLOCK_STAMINA_PER_DAMAGE = 1.0; // stamina drain ratio while blocking
   const BLOCK_STAMINA_MIN_DRAIN = 6;    // ensure even light hits tax stamina
+  const BLOCK_DAMAGE_REDUCTION = 0.8;   // fraction of incoming HP mitigated while blocking
   const HOLD_THRESHOLD_MS = 180;        // how long E must be held to count as Block (not Parry)
   const LANDING_MIN_GROUNDED_MS = 45;   // delay landing anim until on-ground persisted briefly
   const LANDING_SPAM_GRACE_MS = 160;    // suppress landing anim if jump pressed again within this window
@@ -833,6 +834,7 @@
     const playerSprite = {
       mgr: {},
       sizeByAnim: {},
+      frameMeta: {},
       sprite: null,
       state: 'idle',
       sizeUnits: 2,
@@ -843,8 +845,17 @@
     };
 
     const HEAL_FX_META = { url: 'assets/sprites/VFX/heal.png', frames: 6, fps: 6.6667 };
+    const PARRY_FX_META = { url: 'assets/sprites/VFX/Parry FX.png', width: 170, height: 34 };
     const healFx = { mgr: null, sprite: null, sizeUnits: 0, animStart: 0, animDuration: 0, frameH: 0 };
+    const parryReadyFx = {
+      mgr: null,
+      sprite: null,
+      widthUnits: 0,
+      heightUnits: 0,
+      activeUntil: 0
+    };
     const HEAL_FX_FRONT_OFFSET = 0.01;
+    const PARRY_FX_FRONT_OFFSET = 0.015;
     const healFlash = {
       sprite: null,
       manager: null,
@@ -960,6 +971,7 @@
       // Height in world units from pixel height
       const sizeUnits = frameH / PPU;
       playerSprite.sizeByAnim[metaKey] = sizeUnits;
+      playerSprite.frameMeta[metaKey] = { frameW, frameH };
 
       // Baseline auto-detect (idle only)
       if (computeBaseline) {
@@ -1169,6 +1181,87 @@
     }
 
     applyAnimationScale(1);
+
+    function parrySpriteHalfWidthUnits() {
+      const meta = playerSprite.frameMeta?.parry;
+      const heightUnits = playerSprite.sizeByAnim?.parry ?? playerSprite.sizeUnits;
+      if (!heightUnits || heightUnits <= 0) return 0;
+      const frameH = meta?.frameH || 0;
+      const frameW = meta?.frameW || 0;
+      if (frameH > 0 && frameW > 0) {
+        return Math.max(0, heightUnits * (frameW / frameH) * 0.5);
+      }
+      return Math.max(0, heightUnits * 0.5);
+    }
+
+    async function initParryReadyFx() {
+      const { ok, w, h } = await loadImage(PARRY_FX_META.url);
+      if (!ok) { console.warn('Parry FX sprite missing; skipping.'); return; }
+      const frameW = w || PARRY_FX_META.width;
+      const frameH = h || PARRY_FX_META.height;
+      parryReadyFx.widthUnits = frameW / PPU;
+      parryReadyFx.heightUnits = frameH / PPU;
+      const mgr = new BABYLON.SpriteManager('fx_parry_ready', PARRY_FX_META.url, 1,
+        { width: frameW, height: frameH }, scene);
+      mgr.texture.updateSamplingMode(BABYLON.Texture.NEAREST_SAMPLINGMODE);
+      mgr.texture.wrapU = BABYLON.Texture.CLAMP_ADDRESSMODE;
+      mgr.texture.wrapV = BABYLON.Texture.CLAMP_ADDRESSMODE;
+      parryReadyFx.mgr = mgr;
+    }
+
+    function stopParryReadyFx() {
+      if (parryReadyFx.sprite) {
+        parryReadyFx.sprite.dispose();
+        parryReadyFx.sprite = null;
+      }
+      parryReadyFx.activeUntil = 0;
+    }
+
+    function playParryReadyFx(now = performance.now()) {
+      if (!parryReadyFx.mgr) return;
+      if (parryReadyFx.sprite) {
+        parryReadyFx.sprite.dispose();
+      }
+      const sp = new BABYLON.Sprite('fx_parry_ready_active', parryReadyFx.mgr);
+      const heightUnits = parryReadyFx.heightUnits || (parryReadyFx.widthUnits || 0);
+      if (heightUnits > 0) sp.size = heightUnits;
+      if (parryReadyFx.widthUnits > 0) sp.width = parryReadyFx.widthUnits;
+      if (parryReadyFx.heightUnits > 0) sp.height = parryReadyFx.heightUnits;
+      const playerSp = playerSprite.sprite;
+      const basePos = playerSp ? playerSp.position : placeholder.position;
+      const baseZ = (basePos && typeof basePos.z === 'number') ? basePos.z :
+        (typeof placeholder.position.z === 'number' ? placeholder.position.z : 0);
+      const facing = state.facing < 0 ? -1 : 1;
+      const offset = parrySpriteHalfWidthUnits();
+      const targetX = basePos.x + facing * offset;
+      sp.position = new BABYLON.Vector3(targetX, torsoCenterY(), baseZ - PARRY_FX_FRONT_OFFSET);
+      sp.cellIndex = 0;
+      if (playerSp && typeof playerSp.renderingGroupId === 'number') {
+        sp.renderingGroupId = playerSp.renderingGroupId;
+      }
+      parryReadyFx.sprite = sp;
+      parryReadyFx.activeUntil = now + PARRY_WINDOW_MS;
+    }
+
+    function updateParryReadyFx(now) {
+      if (!parryReadyFx.sprite) return;
+      const sp = parryReadyFx.sprite;
+      const playerSp = playerSprite.sprite;
+      const basePos = playerSp ? playerSp.position : placeholder.position;
+      const baseZ = (basePos && typeof basePos.z === 'number') ? basePos.z :
+        (typeof placeholder.position.z === 'number' ? placeholder.position.z : 0);
+      const facing = state.facing < 0 ? -1 : 1;
+      const offset = parrySpriteHalfWidthUnits();
+      sp.position.x = basePos.x + facing * offset;
+      sp.position.y = torsoCenterY();
+      sp.position.z = baseZ - PARRY_FX_FRONT_OFFSET;
+      if (playerSp && typeof playerSp.renderingGroupId === 'number') {
+        sp.renderingGroupId = playerSp.renderingGroupId;
+      }
+      if (now >= parryReadyFx.activeUntil || !state.parryOpen) {
+        stopParryReadyFx();
+      }
+    }
 
     async function initHealFx() {
       const { ok, w: sheetW, h: sheetH } = await loadImage(HEAL_FX_META.url);
@@ -1387,6 +1480,7 @@
     }
       initPlayerSprite();
       initHealFx();
+      initParryReadyFx();
       initHealFlash();
       spawnShrine(-2, 0);
 
@@ -2760,6 +2854,7 @@
       state.flasking = false;
       state.acting = true; // prevent the state machine from swapping parry out
       if (playerSprite.mgr.parry) setAnim('parry', false);
+      playParryReadyFx(now);
       actionEndAt = now + PARRY_WINDOW_MS;
     }
 
@@ -2770,6 +2865,7 @@
       state.blocking = true;
       state.parryOpen = false;
       state.parryUntil = 0;
+      stopParryReadyFx();
       if (playerSprite.mgr.block) setAnim('block', true);
       // Blocking doesn't set acting; you can still move while holding block
     }
@@ -2859,6 +2955,7 @@
       event.parried = true;
       state.parryOpen = false;
       state.parryUntil = now;
+      stopParryReadyFx();
       triggerParryFx(event.source);
       applyParryStagger(event.source, now, PARRY_STAGGER_MS);
       if (playerSprite && playerSprite.animDurationMs) {
@@ -2951,10 +3048,15 @@
           setST(remaining);
         }
       }
-      event.applyDamage = false;
-      event.cancelled = true;
-      event.handled = true;
+      const blockedAmount = rawDamage * BLOCK_DAMAGE_REDUCTION;
+      const damageAfterBlock = Math.max(0, rawDamage - blockedAmount);
+      event.damage = damageAfterBlock;
+      event.applyDamage = damageAfterBlock > 0;
+      event.cancelled = false;
+      event.handled = damageAfterBlock <= 0;
       event.blocked = true;
+      event.blockDamageReduction = BLOCK_DAMAGE_REDUCTION;
+      event.blockedDamage = Math.max(0, rawDamage - damageAfterBlock);
       event.blockStaminaDrain = drain;
       if (guardBroken) {
         event.guardBroken = true;
@@ -3456,6 +3558,7 @@
           stopHealFx();
         }
       }
+      updateParryReadyFx(now);
       updateHealFlash(now);
 
       // Shadow follows X; tiny shrink when airborne


### PR DESCRIPTION
## Summary
- reduce blocked hits to deal 20% damage instead of being fully cancelled while preserving stamina drain and guard break behaviour
- preload and trigger the parry ready FX sprite on parry start, anchoring it to the far edge of the parry animation
- keep the parry FX aligned with the player and remove it when the window closes or transitions into block/parry resolution

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68d8250802a8832fa2b2334caa7dfd2a