### PR TITLE
Align roll invulnerability with roll duration

### DIFF
--- a/main.js
+++ b/main.js
@@ -3341,7 +3341,9 @@
       setST(stats.stam - stats.rollCost);
       const now = performance.now();
       const startOffset = Math.max(0, stats.iFrameStart || 0);
-      const endOffset = Math.max(startOffset, stats.iFrameEnd || 0);
+      const rollDurationOffset = Math.max(startOffset, stats.rollDur || 0);
+      const configuredEndOffset = Math.max(startOffset, stats.iFrameEnd || 0);
+      const endOffset = Math.max(rollDurationOffset, configuredEndOffset);
       const iStart = now + startOffset * 1000;
       const iEnd = now + endOffset * 1000;
       state.rolling = true;


### PR DESCRIPTION
## Summary
- ensure the roll's invulnerability window always lasts through the full animation by clamping its end offset to the roll duration

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d94fbb2144832fb011272ad1b5945c