### PR TITLE
Clamp frame delta

### DIFF
--- a/main.js
+++ b/main.js
@@ -5,6 +5,7 @@
 (() => {
   // ====== Tunables / Fallbacks ======
   const PPU = 32;                       // pixels per world unit
+  const MAX_FRAME_DT = 1 / 30;          // cap dt for gameplay stability per design requirement
   const FALLBACK_BASELINE_PX = 6;       // if pixel-read fails
   const ORTHO_VIEW_HEIGHT = 12;         // vertical world units in view
   const LANDING_MIN_GROUNDED_MS = 45;   // delay landing anim until on-ground persisted briefly
@@ -3610,7 +3611,7 @@
     // === Game loop ===
     engine.runRenderLoop(() => {
       const now = performance.now();
-      const rawDt = engine.getDeltaTime() / 1000;
+      const rawDt = Math.min(engine.getDeltaTime() / 1000, MAX_FRAME_DT);
       const baseScale = slowMo ? 0.25 : 1;
       const hitstopActive = hitstopRemaining(now) > 0;
       const dtScale = hitstopActive ? 0 : baseScale;


### PR DESCRIPTION
## Summary
- introduce a tunable MAX_FRAME_DT constant to cap gameplay timestep
- clamp the render loop delta time so physics and stamina updates respect the maximum frame interval

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d95cba9058832fa8b2913171dde0ec