### PR TITLE
Prevent hero roll from triggering in mid-air

### DIFF
--- a/main.js
+++ b/main.js
@@ -3515,6 +3515,7 @@
 
     function startRoll() {
       if (state.dead || state.rolling) return;
+      if (!state.onGround) return;
       const flasking = state.flasking;
       if (state.acting && !flasking) return;
       if (stats.stam < stats.rollCost) return;


### PR DESCRIPTION
## Summary
- add a grounded check before allowing the roll action to start
- ensure the hero cannot trigger rolling while airborne

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68d9b055d4c8832f9268a26241d5fd78